### PR TITLE
Complex vals

### DIFF
--- a/Muse_P3example.py
+++ b/Muse_P3example.py
@@ -6,15 +6,19 @@
 #python
 from utils import *
 data_dir = 'visual/cueing'
-subs = [101,102]
+subs = [101, 102, 103, 104, 105, 106, 108, 109, 110, 111, 112,
+        202, 203, 204, 205, 207, 208, 209, 210, 211,
+        301, 302, 303, 304, 305, 306, 307, 308, 309]
+        subs = [101, 102, 103, 104]
 nsesh = 2
 event_id = {'LeftCue': 1,'RightCue': 2}
 #Load Data
 raw = LoadMuseData(subs,nsesh,data_dir)
 #Pre-Process EEG Data
-epochs = PreProcess(raw,event_id)
+epochs = PreProcess(raw,event_id,epoch_time=(-1,2))
 #Engineer Features for Model
-feats = FeatureEngineer(epochs)
+feats = FeatureEngineer(epochs,frequency_domain=True,
+						include_phase=True)
 #Create Model
 model,_ = CreateModel(feats)
 #Train with validation, then Test

--- a/Muse_P3example.py
+++ b/Muse_P3example.py
@@ -6,10 +6,7 @@
 #python
 from utils import *
 data_dir = 'visual/cueing'
-subs = [101, 102, 103, 104, 105, 106, 108, 109, 110, 111, 112,
-        202, 203, 204, 205, 207, 208, 209, 210, 211,
-        301, 302, 303, 304, 305, 306, 307, 308, 309]
-        subs = [101, 102, 103, 104]
+subs = [101, 102, 103, 104]
 nsesh = 2
 event_id = {'LeftCue': 1,'RightCue': 2}
 #Load Data

--- a/simulate.py
+++ b/simulate.py
@@ -9,15 +9,17 @@ from utils import *
 # 	raw,event_id = SimulateRaw(amp1=10, amp2=5, freq=2., batch=1)
 # 	raw.save(raw_filename,overwrite=True)
 
-raw,event_id = SimulateRaw(amp1=100, amp2=50, freq=2., batch=4)
-epochs = PreProcess(raw,event_id,filter_data=False,plot_erp=True)
+raw,event_id = SimulateRaw(amp1=100, amp2=50, freq=2., batch=1)
+epochs = PreProcess(raw,event_id,filter_data=False,plot_erp=False,
+					epoch_time=(-1,2))
 
 pick = 33
 for event in event_id.keys():
 	fig = plt.imshow(epochs[event]._data[:,pick,:])
 	plt.show()
 
-feats = FeatureEngineer(epochs,model_type='CNN')
-model,_ = CreateModel(feats, units=[256,128,128,64,32,16])
+feats = FeatureEngineer(epochs,model_type='NN',
+						frequency_domain=True,include_phase=True)
+model,_ = CreateModel(feats, units=[64,32,16])
 TrainTestVal(model,feats)
 

--- a/tests.py
+++ b/tests.py
@@ -76,6 +76,28 @@ class ExampleTest(unittest.TestCase):
 
         self.assertLess(data['acc'], 1)
     
+    def test_frequencydomain_complex(self):
+        """
+        Testing simulated data pipeline.
+        """
+        # Simulate Data
+        raw,event_id = SimulateRaw(amp1=50, amp2=60, freq=1.)
+
+        # Pre-Process EEG Data
+        epochs = PreProcess(raw,event_id)
+
+        # Engineer Features for Model
+        feats = FeatureEngineer(epochs,frequency_domain=True,
+                                include_phase=True)
+
+        # Create Model
+        model, _ = CreateModel(feats, units=[16,16])
+
+        # Train with validation, then Test
+        model, data = TrainTestVal(model,feats, 
+                    train_epochs=1,show_plots=False)
+
+        self.assertLess(data['acc'], 1)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
1) cleaned up the frequency domain code so it loops through events (scaled to > 2 classes), saves dict of time frequency reps
2) added flag to include_phase
3) This flag makes the wavelet code spit out complex values
4) these are then concatenated together
5) turned off automatic normalization of X for this reason
6) tested on the simulated and Muse code examples

Also) modified the electrode selection for wavelet, defaults to 5, choose 'all' at your peril (not enough RAM)
